### PR TITLE
[User-24] 자기소개 저장(수정) 기능 구현

### DIFF
--- a/src/main/java/com/devnity/devnity/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/devnity/devnity/common/config/WebSecurityConfig.java
@@ -57,6 +57,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
           .antMatchers("/api/v1/auth/**").permitAll()
           .antMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
+          .antMatchers(HttpMethod.GET, "/api/v1/users/check").permitAll()
           .antMatchers("/api/v1/admin/**").hasRole("ADMIN")
           .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
           .anyRequest().authenticated()

--- a/src/main/java/com/devnity/devnity/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/devnity/devnity/domain/auth/controller/AuthController.java
@@ -20,8 +20,8 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping("/login")
-  public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
-    return ResponseEntity.ok(ApiResponse.ok(authService.login(request)));
+  public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+    return ApiResponse.ok(authService.login(request));
   }
 
 }

--- a/src/main/java/com/devnity/devnity/domain/introduction/entity/Introduction.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/entity/Introduction.java
@@ -55,9 +55,15 @@ public class Introduction {
   @Enumerated(EnumType.STRING)
   private IntroductionStatus status;
 
+  public Introduction(User user) {
+    this.user = user;
+    this.status = IntroductionStatus.POSTED;
+  }
+
   @Builder
   public Introduction(String profileImgUrl, Mbti mbti, String blogUrl, String githubUrl,
-      String summary, Double latitude, Double longitude, User user, String content) {
+      String summary, Double latitude, Double longitude, String content,
+      IntroductionStatus status) {
     this.profileImgUrl = profileImgUrl;
     this.mbti = mbti;
     this.blogUrl = blogUrl;
@@ -65,12 +71,18 @@ public class Introduction {
     this.summary = summary;
     this.latitude = latitude;
     this.longitude = longitude;
-    this.user = user;
     this.content = content;
-    this.status = IntroductionStatus.POSTED;
+    this.status = status;
   }
 
   public void update(Introduction update) {
-
+    this.profileImgUrl = update.profileImgUrl;
+    this.mbti = update.mbti;
+    this.blogUrl = update.blogUrl;
+    this.githubUrl = update.githubUrl;
+    this.summary = update.summary;
+    this.latitude = update.latitude;
+    this.longitude = update.longitude;
+    this.content = update.content;
   }
 }

--- a/src/main/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepository.java
@@ -3,8 +3,10 @@ package com.devnity.devnity.domain.introduction.respository;
 import com.devnity.devnity.domain.introduction.entity.Introduction;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface IntroductionRepository extends JpaRepository<Introduction, Long> {
 
+  @Query("select i from Introduction i where i.id = :id and i.user.id = :userId and i.status = 'POSTED'")
   Optional<Introduction> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepository.java
@@ -4,9 +4,10 @@ import com.devnity.devnity.domain.introduction.entity.Introduction;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IntroductionRepository extends JpaRepository<Introduction, Long> {
 
   @Query("select i from Introduction i where i.id = :id and i.user.id = :userId and i.status = 'POSTED'")
-  Optional<Introduction> findByIdAndUserId(Long id, Long userId);
+  Optional<Introduction> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/devnity/devnity/domain/user/controller/UserController.java
+++ b/src/main/java/com/devnity/devnity/domain/user/controller/UserController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -44,8 +45,8 @@ public class UserController {
     return ApiResponse.ok();
   }
 
-  @GetMapping("/{email}/check")
-  public ApiResponse<Map> checkEmail(@PathVariable String email) {
+  @GetMapping("/check")
+  public ApiResponse<Map> checkEmail(@RequestParam("email") String email) {
     return ApiResponse.ok(Collections.singletonMap("isDuplicated", userService.existsByEmail(email)));
   }
 

--- a/src/main/java/com/devnity/devnity/domain/user/entity/User.java
+++ b/src/main/java/com/devnity/devnity/domain/user/entity/User.java
@@ -75,7 +75,7 @@ public class User {
     this.generation = generation;
     this.course = course;
     this.status = UserStatus.JOIN;
-    this.introduction = Introduction.builder().build();
+    this.introduction = new Introduction(this);
   }
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/devnity/devnity/domain/user/entity/User.java
+++ b/src/main/java/com/devnity/devnity/domain/user/entity/User.java
@@ -85,11 +85,11 @@ public class User {
     return this.getGroup().getAuthorities();
   }
 
-  public String getCourse() {
+  public String getCourseName() {
     return this.course.getName();
   }
 
-  public int getGeneration() {
+  public int getGenerationSequence() {
     return this.generation.getSequence();
   }
 

--- a/src/main/java/com/devnity/devnity/domain/user/repository/CourseRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/CourseRepository.java
@@ -4,6 +4,6 @@ import com.devnity.devnity.domain.user.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
-
+  // TODO: Optional 달기
   Course findByName(String name);
 }

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
@@ -44,8 +44,8 @@ public class UserService {
     // TODO: Prifile Image 추가
    return UserDto.builder()
         .userId(user.getId())
-        .course(user.getCourse())
-        .generation(user.getGeneration())
+        .course(user.getCourseName())
+        .generation(user.getGenerationSequence())
         .name(user.getName())
         .role(user.getRole().toString())
         .build();

--- a/src/test/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.devnity.devnity.domain.introduction.entity.Introduction;
+import com.devnity.devnity.domain.introduction.entity.IntroductionStatus;
 import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.Group;
@@ -53,5 +54,6 @@ class IntroductionRepositoryTest {
     // then
     List<Introduction> list = introductionRepository.findAll();
     assertThat(list).isNotEmpty();
+    assertThat(list.get(0).getStatus()).isEqualTo(IntroductionStatus.POSTED);
   }
 }

--- a/src/test/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceTest.java
+++ b/src/test/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceTest.java
@@ -1,0 +1,73 @@
+package com.devnity.devnity.domain.introduction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.devnity.devnity.domain.introduction.entity.Introduction;
+import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+import com.devnity.devnity.domain.user.dto.request.SaveIntroductionRequest;
+import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.domain.user.entity.Group;
+import com.devnity.devnity.domain.user.entity.Mbti;
+import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.entity.UserRole;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IntroductionServiceTest {
+
+  @InjectMocks private IntroductionService introductionService;
+
+  @Mock private IntroductionRepository introductionRepository;
+
+  @DisplayName("자기소개가 저장된다")
+  @Test
+  public void testSaveIntroduction() throws Exception {
+    // given
+    SaveIntroductionRequest request = SaveIntroductionRequest.builder()
+        .blogUrl("blog")
+        .content("content")
+        .githubUrl("github")
+        .latitude(123.123)
+        .longitude(445.455)
+        .mbti(Mbti.ENFA)
+        .profileImgUrl("profile")
+        .summary("summary")
+        .build();
+
+    User user = User.builder()
+        .email("email@gmail.com")
+        .role(UserRole.STUDENT)
+        .password("password")
+        .name("seunghun")
+        .group(new Group("group"))
+        .generation(new Generation(1))
+        .course(new Course("FE"))
+        .build();
+
+    Introduction introduction = user.getIntroduction();
+
+    given(introductionRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(introduction));
+    // when
+    introductionService.save(1L, 1L, request);
+
+    // then
+    assertThat(introduction.getContent()).isEqualTo(request.getContent());
+    assertThat(introduction.getBlogUrl()).isEqualTo(request.getBlogUrl());
+    assertThat(introduction.getGithubUrl()).isEqualTo(request.getGithubUrl());
+    assertThat(introduction.getLatitude()).isEqualTo(request.getLatitude());
+    assertThat(introduction.getLongitude()).isEqualTo(request.getLongitude());
+    assertThat(introduction.getMbti()).isEqualTo(request.getMbti());
+    assertThat(introduction.getSummary()).isEqualTo(request.getSummary());
+    assertThat(introduction.getProfileImgUrl()).isEqualTo(request.getProfileImgUrl());
+  }
+  
+  
+}

--- a/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
@@ -105,7 +105,7 @@ class UserControllerTest {
         .role(UserRole.STUDENT)
         .name("seunghun")
         .password("password123")
-        .email("email@gmail.com")
+        .email("email123123@gmail.com")
         .course("FE")
         .build();
 
@@ -136,15 +136,12 @@ class UserControllerTest {
 
     //when
     ResultActions actions = mockMvc.perform(
-        get("/api/v1/users/{email}/check", email));
+        get("/api/v1/users/check?email="+email));
 
     //then
     actions.andExpect(status().isOk())
         .andDo(print())
         .andDo(document("users/email-check", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()),
-            pathParameters(
-                parameterWithName("email").description("이메일")
-            ),
             responseFields(
                 fieldWithPath("statusCode").type(NUMBER).description("상태 코드"),
                 fieldWithPath("data").type(OBJECT).description("응답 데이터"),

--- a/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.devnity.devnity.domain.user.controller;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -18,8 +19,14 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+import com.devnity.devnity.domain.user.dto.request.SaveIntroductionRequest;
 import com.devnity.devnity.domain.user.dto.request.SignUpRequest;
+import com.devnity.devnity.domain.user.entity.Mbti;
+import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.test.annotation.WithJwtAuthUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import javax.sql.DataSource;
@@ -36,12 +43,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @AutoConfigureRestDocs
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 @SpringBootTest
 class UserControllerTest {
 
@@ -51,20 +59,43 @@ class UserControllerTest {
 
   @Autowired private DataSource dataSource;
 
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private IntroductionRepository introductionRepository;
+
+  private User user;
+
   @BeforeAll
   void init() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
       ScriptUtils.executeSqlScript(conn, new ClassPathResource("data.sql"));
     }
+
+    User base = userRepository.findUserByEmail("user@gmail.com").get();
+
+    user = User.builder()
+            .email("email@gmail.com")
+            .course(base.getCourse())
+            .generation(base.getGeneration())
+            .password("password")
+            .name("seunghun")
+            .role(UserRole.STUDENT)
+            .group(base.getGroup())
+            .build();
+
+    userRepository.save(user);
   }
 
   @AfterAll
   void clean() throws Exception {
+    introductionRepository.deleteAll();
+
     try (Connection conn = dataSource.getConnection()) {
       ScriptUtils.executeSqlScript(conn, new ClassPathResource("truncate-data.sql"));
     }
   }
 
+  @WithAnonymousUser
   @DisplayName("회원가입 할 수 있다")
   @Test
   public void testSignUp() throws Exception {
@@ -96,12 +127,12 @@ class UserControllerTest {
               )));
   }
 
+  @WithAnonymousUser
   @DisplayName("이메일 중복 확인 할 수 있다")
   @Test
   public void testCheckEmail() throws Exception {
     // given
-    String email = "user@gmail.com";
-
+    String email = user.getEmail();
 
     //when
     ResultActions actions = mockMvc.perform(
@@ -120,5 +151,55 @@ class UserControllerTest {
                 fieldWithPath("data.isDuplicated").type(BOOLEAN).description("중복 확인"),
                 fieldWithPath("serverDatetime").type(STRING).description("서버 시간")
             )));
+  }
+
+  @WithJwtAuthUser(email = "email@gmail.com", roles = "USER")
+  @DisplayName("자기소개가 저장된다")
+  @Test
+  public void testSaveIntroduction() throws Exception {
+    // given
+
+    SaveIntroductionRequest request =
+        SaveIntroductionRequest.builder()
+            .blogUrl("blog")
+            .content("content")
+            .githubUrl("github")
+            .latitude(123.123)
+            .longitude(445.455)
+            .mbti(Mbti.ENFA)
+            .profileImgUrl("profile")
+            .summary("summary")
+            .build();
+
+    // when
+    ResultActions actions =
+        mockMvc.perform(
+            put("/api/v1/users/me/introduction/{introductionId}", user.getIntroduction().getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    actions
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andDo(
+            document(
+                "users/introduction/save",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("introductionId").description("자기소개 id")),
+                requestFields(
+                    fieldWithPath("profileImgUrl").type(STRING).description("프로필 이미지 URL"),
+                    fieldWithPath("mbti").type(STRING).description("MBTI"),
+                    fieldWithPath("blogUrl").type(STRING).description("블로그 URL"),
+                    fieldWithPath("githubUrl").type(STRING).description("깃허브 URL"),
+                    fieldWithPath("summary").type(STRING).description("한 줄 소개"),
+                    fieldWithPath("latitude").type(NUMBER).description("위도"),
+                    fieldWithPath("longitude").type(NUMBER).description("경도"),
+                    fieldWithPath("content").type(STRING).description("자기소개 본문")),
+                responseFields(
+                    fieldWithPath("statusCode").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("data").type(STRING).description("응답 데이터"),
+                    fieldWithPath("serverDatetime").type(STRING).description("서버 시간"))));
   }
 }

--- a/src/test/java/com/devnity/devnity/test/annotation/WithJwtAuthUser.java
+++ b/src/test/java/com/devnity/devnity/test/annotation/WithJwtAuthUser.java
@@ -1,0 +1,14 @@
+package com.devnity.devnity.test.annotation;
+
+import com.devnity.devnity.test.config.WithJwtAuthUserSecurityContext;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithJwtAuthUserSecurityContext.class)
+public @interface WithJwtAuthUser {
+
+  String email();
+  String[] roles();
+}

--- a/src/test/java/com/devnity/devnity/test/config/WithJwtAuthUserSecurityContext.java
+++ b/src/test/java/com/devnity/devnity/test/config/WithJwtAuthUserSecurityContext.java
@@ -1,0 +1,51 @@
+package com.devnity.devnity.test.config;
+
+import com.devnity.devnity.domain.auth.jwt.Jwt;
+import com.devnity.devnity.domain.auth.jwt.Jwt.Claims;
+import com.devnity.devnity.domain.auth.jwt.JwtAuthentication;
+import com.devnity.devnity.domain.auth.jwt.JwtAuthenticationToken;
+import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.test.annotation.WithJwtAuthUser;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithJwtAuthUserSecurityContext implements WithSecurityContextFactory<WithJwtAuthUser> {
+
+  private final Jwt jwt;
+  private final UserRepository userRepository;
+
+  public WithJwtAuthUserSecurityContext(Jwt jwt, UserRepository userRepository) {
+    this.jwt = jwt;
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public SecurityContext createSecurityContext(WithJwtAuthUser withJwtAuthUser) {
+    String email = withJwtAuthUser.email();
+    String[] roles = withJwtAuthUser.roles();
+    User user = userRepository
+        .findUserByEmail(email)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format("There is no user for email = %s", email)));
+
+    String jwtToken = jwt.sign(Claims.from(user.getId(), email, roles));
+
+    JwtAuthentication authentication = new JwtAuthentication(jwtToken, user.getId(), email);
+    JwtAuthenticationToken jwtAuthenticationToken =
+        new JwtAuthenticationToken(
+            authentication,
+            user.getPassword(),
+            Arrays.stream(roles).map(SimpleGrantedAuthority::new).collect(Collectors.toList()));
+
+    SecurityContextHolder.getContext().setAuthentication(jwtAuthenticationToken);
+    return SecurityContextHolder.getContext();
+  }
+
+}


### PR DESCRIPTION
## ❓ 관련 이슈 <!-- 해당 PR과 관련된 모든 이슈의 태그를 걸어주세요  (ex : - #이슈번호) -->

- issue: #24 

<br>

## 💨 한줄 요약 <!-- 해당 PR에 한줄로 요약해주세요 -->

자기소개 저장 및 수정 기능 구현

<br>


## ✔ 변경사항 <!-- 변경된 사항에 대해 설명해주세요 -->

- 이메일 중복확인 요청이 PathVariable에서 QueryString으로 변경되었음.
- Spring Security 권한 설정이 변경되었음

<br>

## ⚠ 특이사항 <!-- 특이사항(다른 사람의 패키지를 변경)이 있다면 해당 인원을 태그하고 설명해주세요. (ex : @깃허브ID)  -->

- data.sql로 인해 테스트에 어려움을 겪는 경우가 많아 개선 필요있음
- WithJwtAuthUser 어노테이션 생성

<br>

## ⏰ 소요시간 <!-- 해당 작업이 걸린 시간을 대략적으로 써주세요 (ex : 3h) -->

5h

<br>


