### PR TITLE
[User - 69] 메인페이지 자기소개 추천 기능 구현

### DIFF
--- a/src/main/java/com/devnity/devnity/common/config/QueryDslConfig.java
+++ b/src/main/java/com/devnity/devnity/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.devnity.devnity.common.config;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/devnity/devnity/domain/introduction/controller/IntroductionController.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/controller/IntroductionController.java
@@ -1,0 +1,26 @@
+package com.devnity.devnity.domain.introduction.controller;
+
+import com.devnity.devnity.common.api.ApiResponse;
+import com.devnity.devnity.domain.auth.jwt.JwtAuthentication;
+import com.devnity.devnity.domain.introduction.dto.response.SuggestResponse;
+import com.devnity.devnity.domain.introduction.service.IntroductionService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/introductions")
+@RestController
+public class IntroductionController {
+
+  private final IntroductionService introductionService;
+
+  @GetMapping("/suggest")
+  public ApiResponse<List<SuggestResponse>> suggest(
+      @AuthenticationPrincipal JwtAuthentication jwtAuthentication) {
+    return ApiResponse.ok(introductionService.suggest(jwtAuthentication.getUserId()));
+  }
+}

--- a/src/main/java/com/devnity/devnity/domain/introduction/dto/IntroductionDto.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/dto/IntroductionDto.java
@@ -9,10 +9,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@JsonInclude(Include.NON_NULL)
 @Getter
 @NoArgsConstructor
 public class IntroductionDto {
+
   private Long introductionId;
   private String profileImgUrl;
   private Mbti mbti;
@@ -21,14 +21,26 @@ public class IntroductionDto {
   private String summary;
   private Double latitude;
   private Double longitude;
+
+  @JsonInclude(Include.NON_NULL)
   private String description;
+
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   @Builder
-  public IntroductionDto(Long introductionId, String profileImgUrl,
-    Mbti mbti, String blogUrl, String githubUrl, String summary, Double latitude,
-    Double longitude, LocalDateTime createdAt, LocalDateTime updatedAt, String description) {
+  public IntroductionDto(
+      Long introductionId,
+      String profileImgUrl,
+      Mbti mbti,
+      String blogUrl,
+      String githubUrl,
+      String summary,
+      Double latitude,
+      Double longitude,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt,
+      String description) {
     this.introductionId = introductionId;
     this.profileImgUrl = profileImgUrl;
     this.mbti = mbti;
@@ -59,18 +71,18 @@ public class IntroductionDto {
 
   public static IntroductionDto of(Introduction introduction, String description) {
     return IntroductionDto.builder()
-      .introductionId(introduction.getId())
-      .profileImgUrl(introduction.getProfileImgUrl())
-      .mbti(introduction.getMbti())
-      .blogUrl(introduction.getBlogUrl())
-      .githubUrl(introduction.getGithubUrl())
-      .summary(introduction.getSummary())
-      .latitude(introduction.getLatitude())
-      .longitude(introduction.getLongitude())
-      .createdAt(introduction.getCreatedAt())
-      .updatedAt(introduction.getModifiedAt())
-      .description(description)
-      .build();
+        .introductionId(introduction.getId())
+        .profileImgUrl(introduction.getProfileImgUrl())
+        .mbti(introduction.getMbti())
+        .blogUrl(introduction.getBlogUrl())
+        .githubUrl(introduction.getGithubUrl())
+        .summary(introduction.getSummary())
+        .latitude(introduction.getLatitude())
+        .longitude(introduction.getLongitude())
+        .createdAt(introduction.getCreatedAt())
+        .updatedAt(introduction.getModifiedAt())
+        .description(description)
+        .build();
   }
 
   @Override

--- a/src/main/java/com/devnity/devnity/domain/introduction/dto/IntroductionDto.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/dto/IntroductionDto.java
@@ -2,11 +2,14 @@ package com.devnity.devnity.domain.introduction.dto;
 
 import com.devnity.devnity.domain.introduction.entity.Introduction;
 import com.devnity.devnity.domain.user.entity.Mbti;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonInclude(Include.NON_NULL)
 @Getter
 @NoArgsConstructor
 public class IntroductionDto {
@@ -18,13 +21,14 @@ public class IntroductionDto {
   private String summary;
   private Double latitude;
   private Double longitude;
+  private String description;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   @Builder
   public IntroductionDto(Long introductionId, String profileImgUrl,
-      Mbti mbti, String blogUrl, String githubUrl, String summary, Double latitude,
-      Double longitude, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    Mbti mbti, String blogUrl, String githubUrl, String summary, Double latitude,
+    Double longitude, LocalDateTime createdAt, LocalDateTime updatedAt, String description) {
     this.introductionId = introductionId;
     this.profileImgUrl = profileImgUrl;
     this.mbti = mbti;
@@ -35,6 +39,7 @@ public class IntroductionDto {
     this.longitude = longitude;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.description = description;
   }
 
   public static IntroductionDto of(Introduction introduction) {
@@ -50,6 +55,22 @@ public class IntroductionDto {
         .createdAt(introduction.getCreatedAt())
         .updatedAt(introduction.getModifiedAt())
         .build();
+  }
+
+  public static IntroductionDto of(Introduction introduction, String description) {
+    return IntroductionDto.builder()
+      .introductionId(introduction.getId())
+      .profileImgUrl(introduction.getProfileImgUrl())
+      .mbti(introduction.getMbti())
+      .blogUrl(introduction.getBlogUrl())
+      .githubUrl(introduction.getGithubUrl())
+      .summary(introduction.getSummary())
+      .latitude(introduction.getLatitude())
+      .longitude(introduction.getLongitude())
+      .createdAt(introduction.getCreatedAt())
+      .updatedAt(introduction.getModifiedAt())
+      .description(description)
+      .build();
   }
 
   @Override

--- a/src/main/java/com/devnity/devnity/domain/introduction/dto/response/SuggestResponse.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/dto/response/SuggestResponse.java
@@ -1,0 +1,24 @@
+package com.devnity.devnity.domain.introduction.dto.response;
+
+import com.devnity.devnity.domain.introduction.dto.IntroductionDto;
+import com.devnity.devnity.domain.user.dto.UserDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SuggestResponse {
+
+  private UserDto user;
+  private IntroductionDto introduction;
+
+  private SuggestResponse(UserDto user,
+    IntroductionDto introduction) {
+    this.user = user;
+    this.introduction = introduction;
+  }
+
+  public static SuggestResponse of(UserDto user, IntroductionDto introduction) {
+    return new SuggestResponse(user, introduction);
+  }
+}

--- a/src/main/java/com/devnity/devnity/domain/introduction/service/IntroductionService.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/service/IntroductionService.java
@@ -1,10 +1,18 @@
 package com.devnity.devnity.domain.introduction.service;
 
+import com.devnity.devnity.domain.introduction.dto.IntroductionDto;
+import com.devnity.devnity.domain.introduction.dto.response.SuggestResponse;
 import com.devnity.devnity.domain.introduction.entity.Introduction;
 import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+import com.devnity.devnity.domain.user.dto.UserDto;
 import com.devnity.devnity.domain.user.dto.request.SaveIntroductionRequest;
 import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.domain.user.service.UserServiceUtils;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.realm.UserDatabaseRealm;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,19 +21,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class IntroductionService {
 
+  private static final int SUGGESTION_SIZE = 15;
+
   private final IntroductionRepository introductionRepository;
+
+  private final UserRepository userRepository;
 
   @Transactional
   public void save(Long userId, Long introductionId, SaveIntroductionRequest request) {
-    Introduction introduction = introductionRepository
-        .findByIdAndUserId(introductionId, userId)
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    String.format(
-                        "There is no introduction. userId=%d, introductionId=%d",
-                        userId, introductionId)));
+    Introduction introduction =
+        IntroductionServiceUtils.findIntroductionByIdAndUserId(
+            introductionRepository, userId, introductionId);
 
     introduction.update(request.toEntity());
+  }
+
+  public List<SuggestResponse> suggest(Long userId) {
+    User user = UserServiceUtils.findUser(userRepository, userId);
+
+    return userRepository
+        .findAllByCourseAndGenerationLimit(user, SUGGESTION_SIZE)
+        .stream()
+        .map(u -> SuggestResponse.of(UserDto.of(u), IntroductionDto.of(u.getIntroduction())))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceUtils.java
+++ b/src/main/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceUtils.java
@@ -1,0 +1,19 @@
+package com.devnity.devnity.domain.introduction.service;
+
+import com.devnity.devnity.domain.introduction.entity.Introduction;
+import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+
+public class IntroductionServiceUtils {
+
+  public static Introduction findIntroductionByIdAndUserId(
+      IntroductionRepository introductionRepository, Long userId, Long introductionId) {
+    return introductionRepository
+      .findByIdAndUserId(introductionId, userId)
+      .orElseThrow(
+        () ->
+          new IllegalArgumentException(
+            String.format(
+              "There is no introduction. userId=%d, introductionId=%d",
+              userId, introductionId)));
+  }
+}

--- a/src/main/java/com/devnity/devnity/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/devnity/devnity/domain/user/dto/request/SignUpRequest.java
@@ -1,6 +1,5 @@
 package com.devnity.devnity.domain.user.dto.request;
 
-import com.devnity.devnity.domain.user.entity.Authority;
 import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.User;

--- a/src/main/java/com/devnity/devnity/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/devnity/devnity/domain/user/dto/request/SignUpRequest.java
@@ -50,7 +50,6 @@ public class SignUpRequest {
       PasswordEncoder passwordEncoder, Course course, Generation generation) {
 
     return User.builder()
-        .authority(role == UserRole.MANAGER ? Authority.ADMIN : Authority.USER)
         .role(role)
         .name(name)
         .generation(generation)

--- a/src/main/java/com/devnity/devnity/domain/user/entity/Authority.java
+++ b/src/main/java/com/devnity/devnity/domain/user/entity/Authority.java
@@ -1,5 +1,6 @@
 package com.devnity.devnity.domain.user.entity;
 
+import com.mysema.commons.lang.Assert;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +12,13 @@ public enum Authority {
 
   private final String role;
   private final String description;
+
+  public static Authority of(UserRole userRole) {
+
+    Assert.notNull(userRole, "UserRole must be provided");
+
+    if (userRole.equals(UserRole.MENTOR))
+      return ADMIN;
+    return USER;
+  }
 }

--- a/src/main/java/com/devnity/devnity/domain/user/entity/User.java
+++ b/src/main/java/com/devnity/devnity/domain/user/entity/User.java
@@ -58,7 +58,11 @@ public class User extends BaseEntity {
   @JoinColumn(name = "course_id", nullable = false)
   private Course course;
 
-  @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+  @OneToOne(
+      mappedBy = "user",
+      fetch = FetchType.LAZY,
+      cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+      orphanRemoval = true)
   private Introduction introduction;
 
   @Enumerated(EnumType.STRING)
@@ -66,12 +70,12 @@ public class User extends BaseEntity {
 
   @Builder
   public User(String email, String password, String name, UserRole role,
-      Generation generation, Course course, Authority authority) {
+      Generation generation, Course course) {
     this.email = email;
     this.password = password;
     this.name = name;
     this.role = role;
-    this.authority = authority;
+    this.authority = Authority.of(role);
     this.generation = generation;
     this.course = course;
     this.status = UserStatus.JOIN;

--- a/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepository.java
@@ -1,0 +1,11 @@
+package com.devnity.devnity.domain.user.repository;
+
+import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.domain.user.entity.User;
+import java.util.List;
+
+public interface UserCustomRepository {
+
+  List<User> findAllByCourseAndGenerationLimit(Course course, Generation generation, int size);
+}

--- a/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepository.java
@@ -1,11 +1,9 @@
 package com.devnity.devnity.domain.user.repository;
 
-import com.devnity.devnity.domain.user.entity.Course;
-import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.User;
 import java.util.List;
 
 public interface UserCustomRepository {
 
-  List<User> findAllByCourseAndGenerationLimit(Course course, Generation generation, int size);
+  List<User> findAllByCourseAndGenerationLimit(User user, int size);
 }

--- a/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.devnity.devnity.domain.user.repository;
+
+import static com.devnity.devnity.domain.user.entity.QUser.user;
+
+import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.domain.user.entity.QUser;
+import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.entity.UserStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<User> findAllByCourseAndGenerationLimit(Course course, Generation generation, int size) {
+    return jpaQueryFactory
+        .selectFrom(user)
+        .where(
+          user.course.eq(course),
+          user.generation.eq(generation),
+          user.status.eq(UserStatus.JOIN)
+        )
+        .orderBy(user.id.desc())
+        .limit(size)
+        .fetch();
+  }
+}

--- a/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/UserCustomRepositoryImpl.java
@@ -2,9 +2,6 @@ package com.devnity.devnity.domain.user.repository;
 
 import static com.devnity.devnity.domain.user.entity.QUser.user;
 
-import com.devnity.devnity.domain.user.entity.Course;
-import com.devnity.devnity.domain.user.entity.Generation;
-import com.devnity.devnity.domain.user.entity.QUser;
 import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,12 +14,13 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public List<User> findAllByCourseAndGenerationLimit(Course course, Generation generation, int size) {
+  public List<User> findAllByCourseAndGenerationLimit(User inputUser, int size) {
     return jpaQueryFactory
         .selectFrom(user)
         .where(
-          user.course.eq(course),
-          user.generation.eq(generation),
+          user.course.eq(inputUser.getCourse()),
+          user.generation.eq(inputUser.getGeneration()),
+          user.ne(inputUser),
           user.status.eq(UserStatus.JOIN)
         )
         .orderBy(user.id.desc())

--- a/src/main/java/com/devnity/devnity/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/user/repository/UserRepository.java
@@ -4,7 +4,7 @@ import com.devnity.devnity.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
   Optional<User> findUserByEmail(String email);
 
   boolean existsByEmail(String email);

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.devnity.devnity.domain.user.service;
 
 import com.devnity.devnity.domain.introduction.dto.IntroductionDto;
+import com.devnity.devnity.domain.introduction.entity.Introduction;
 import com.devnity.devnity.domain.user.dto.SimpleUserInfoDto;
 import com.devnity.devnity.domain.user.dto.UserDto;
 import com.devnity.devnity.domain.user.dto.request.SignUpRequest;
@@ -31,7 +32,8 @@ public class UserService {
 
   public UserInfoResponse getUserInfo(Long userId) {
     User user = UserServiceUtils.findUser(userRepository, userId);
-    return new UserInfoResponse(UserDto.of(user), IntroductionDto.of(user.getIntroduction()));
+    Introduction introduction = user.getIntroduction();
+    return new UserInfoResponse(UserDto.of(user), IntroductionDto.of(introduction, introduction.getContent()));
   }
 
   private SimpleUserInfoDto getSimpleUserInfo(Long userId) {

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
@@ -30,20 +30,13 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
 
   public UserInfoResponse getUserInfo(Long userId) {
-    User user = findUserBy(userId);
+    User user = UserServiceUtils.findUser(userRepository, userId);
     return new UserInfoResponse(UserDto.of(user), IntroductionDto.of(user.getIntroduction()));
   }
 
   private SimpleUserInfoDto getSimpleUserInfo(Long userId) {
-    User user = findUserBy(userId);
+    User user = UserServiceUtils.findUser(userRepository, userId);
     return SimpleUserInfoDto.of(user, user.getIntroduction().getProfileImgUrl());
-  }
-
-  private User findUserBy(Long userId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalArgumentException(
-            String.format("There is no user for id = %d", userId)));
-    return user;
   }
 
   @Transactional

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserService.java
@@ -47,10 +47,8 @@ public class UserService {
     checkDuplicatedEmail(request.getEmail());
 
     Course course = UserServiceUtils.findCourse(courseRepository, request.getCourse());
-
     Generation generation = UserServiceUtils.findGeneration(generationRepository,
         request.getGeneration());
-
     User user = request.toEntity(passwordEncoder, course, generation);
 
     userRepository.save(user);

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserServiceUtils.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserServiceUtils.java
@@ -7,8 +7,12 @@ import com.devnity.devnity.domain.user.entity.UserRole;
 import com.devnity.devnity.domain.user.repository.CourseRepository;
 import com.devnity.devnity.domain.user.repository.GenerationRepository;
 import com.devnity.devnity.domain.user.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserServiceUtils {
   public static Generation findGeneration(GenerationRepository generationRepository, int sequence) {
     return generationRepository.findBySequence(sequence)

--- a/src/main/java/com/devnity/devnity/domain/user/service/UserServiceUtils.java
+++ b/src/main/java/com/devnity/devnity/domain/user/service/UserServiceUtils.java
@@ -2,12 +2,13 @@ package com.devnity.devnity.domain.user.service;
 
 import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserRole;
 import com.devnity.devnity.domain.user.repository.CourseRepository;
 import com.devnity.devnity.domain.user.repository.GenerationRepository;
+import com.devnity.devnity.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Component;
 
-@Component
 public class UserServiceUtils {
   public static Generation findGeneration(GenerationRepository generationRepository, int sequence) {
     return generationRepository.findBySequence(sequence)
@@ -17,5 +18,11 @@ public class UserServiceUtils {
   public static Course findCourse(CourseRepository courseRepository, String name) {
     return courseRepository.findByName(name)
       .orElseThrow(() -> new IllegalArgumentException(String.format("There is no course for name = %s", name)));
+  }
+
+  public static User findUser(UserRepository userRepository, Long userId) {
+    return userRepository.findById(userId)
+      .orElseThrow(() -> new IllegalArgumentException(
+        String.format("There is no user for id = %d", userId)));
   }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,7 +8,6 @@ VALUES (1, 'BE'),
        (2, 'FE')
 ;
 
-
 -- user 비밀번호 : user123
 -- admin 비밀번호 : admin123
 INSERT INTO user(id, email, name, role, status, course_id, generation_id, password, authority)

--- a/src/test/java/com/devnity/devnity/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/auth/controller/AuthControllerTest.java
@@ -15,6 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.devnity.devnity.domain.auth.dto.request.LoginRequest;
+import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+import com.devnity.devnity.domain.introduction.service.IntroductionService;
 import com.devnity.devnity.domain.user.entity.Authority;
 import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
@@ -52,8 +54,9 @@ import org.springframework.test.web.servlet.ResultActions;
 @SpringBootTest
 class AuthControllerTest {
 
-  @Autowired
-  private UserRepository userRepository;
+  @Autowired private IntroductionRepository introductionRepository;
+
+  @Autowired private UserRepository userRepository;
 
   @Autowired private GenerationRepository generationRepository;
 
@@ -75,13 +78,20 @@ class AuthControllerTest {
     user =
         User.builder()
             .email("user@gmail.com")
-            .authority(Authority.USER)
             .role(UserRole.STUDENT)
             .name("seunghun")
             .password(passwordEncoder.encode("user123"))
             .course(course)
             .generation(generation)
             .build();
+  }
+
+  @AfterAll
+  void clean() {
+    introductionRepository.deleteAll();
+    userRepository.deleteAll();
+    generationRepository.deleteAll();
+    courseRepository.deleteAll();
   }
 
   @DisplayName("로그인 할 수 있다")

--- a/src/test/java/com/devnity/devnity/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/devnity/devnity/domain/auth/service/AuthServiceTest.java
@@ -41,7 +41,6 @@ class AuthServiceTest {
       .course(new Course("백엔드"))
       .email("admin@naver.com")
       .generation(new Generation(1))
-      .authority(Authority.USER)
       .password("password")
       .role(UserRole.MANAGER)
       .name("seunghun")

--- a/src/test/java/com/devnity/devnity/domain/gather/repository/GatherRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/gather/repository/GatherRepositoryTest.java
@@ -12,6 +12,7 @@ import com.devnity.devnity.domain.user.entity.UserRole;
 import com.devnity.devnity.domain.user.repository.CourseRepository;
 import com.devnity.devnity.domain.user.repository.GenerationRepository;
 import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.test.config.TestConfig;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -20,12 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 //@Sql(classpath:data.sql)
 //@SpringBootTest
+@Import(TestConfig.class)
 @ExtendWith(SpringExtension.class)  // test app-context를 junit에 포함시킴
 @DataJpaTest  // Jpa 관련 설정만 불러옴
 @Slf4j
@@ -56,7 +59,6 @@ class GatherRepositoryTest {
     Course course = new Course("BE");
     User user =
         User.builder()
-            .authority(Authority.USER)
             .email("test@mail.com")
             .name("test")
             .role(UserRole.STUDENT)
@@ -102,7 +104,6 @@ class GatherRepositoryTest {
     Generation generation = generationRepository.save(new Generation(1));
 
     User temp = User.builder()
-      .authority(Authority.USER)
       .course(course)
       .generation(generation)
       .email("test@mail.com")

--- a/src/test/java/com/devnity/devnity/domain/introduction/controller/IntroductionControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/introduction/controller/IntroductionControllerTest.java
@@ -1,0 +1,186 @@
+package com.devnity.devnity.domain.introduction.controller;
+
+import static java.lang.constant.ConstantDescs.NULL;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devnity.devnity.domain.introduction.entity.Introduction;
+import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
+import com.devnity.devnity.domain.introduction.service.IntroductionService;
+import com.devnity.devnity.domain.user.dto.request.SaveIntroductionRequest;
+import com.devnity.devnity.domain.user.entity.Authority;
+import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.domain.user.entity.Mbti;
+import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.domain.user.repository.CourseRepository;
+import com.devnity.devnity.domain.user.repository.GenerationRepository;
+import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.test.annotation.WithJwtAuthUser;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(Lifecycle.PER_CLASS)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@SpringBootTest
+class IntroductionControllerTest {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private IntroductionService introductionService;
+
+  @Autowired private IntroductionRepository introductionRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private CourseRepository courseRepository;
+
+  @Autowired private GenerationRepository generationRepository;
+
+  @AfterEach
+  void clear() {
+    introductionRepository.deleteAll();
+    userRepository.deleteAll();
+    courseRepository.deleteAll();
+    generationRepository.deleteAll();
+  }
+
+  @Test
+  @WithJwtAuthUser(email = "email@gmail.com", role = UserRole.STUDENT)
+  @DisplayName("메인페이지 자기소개 추천")
+  public void testSuggest() throws Exception {
+    // given
+
+    Course course =
+        courseRepository.findByName("FE").orElseGet(() -> courseRepository.save(new Course("FE")));
+
+    Generation generation =
+        generationRepository
+            .findBySequence(1)
+            .orElseGet(() -> generationRepository.save(new Generation(1)));
+
+
+
+    List<User> users = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      users.add(
+          User.builder()
+              .course(course)
+              .generation(generation)
+              .password("password" + i)
+              .name("name" + i)
+              .email(i + "email@naver.com")
+              .role(UserRole.STUDENT)
+              .build());
+    }
+
+
+    userRepository.saveAll(users);
+    for (int i = 0; i < 5; i++) {
+      User user = userRepository.findUserByEmail(users.get(i).getEmail()).get();
+
+      introductionService.save(
+          user.getId(),
+          user.getIntroduction().getId(),
+          SaveIntroductionRequest.builder()
+              .summary("summary")
+              .profileImgUrl("profile")
+              .mbti(Mbti.ENFA)
+              .longitude(123.123)
+              .latitude(123.123)
+              .githubUrl("github")
+              .blogUrl("blog")
+              .content("content")
+              .build());
+    }
+
+    // when
+    ResultActions actions =
+        mockMvc.perform(
+            get("/api/v1/introductions/suggest").header("Authorization", "JSON WEB TOKEN"));
+
+    // then
+    actions
+      .andExpect(status().isOk())
+      .andDo(print())
+      .andDo(document("introductions/suggest", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()),
+        responseFields(
+          fieldWithPath("statusCode").type(NUMBER).description("상태 코드"),
+          fieldWithPath("data").type(ARRAY).description("응답 데이터"),
+          fieldWithPath("data[].user").type(OBJECT).description("사용자 정보"),
+          fieldWithPath("data[].user.userId").type(NUMBER).description("사용자 ID"),
+          fieldWithPath("data[].user.email").type(STRING).description("이메일"),
+          fieldWithPath("data[].user.name").type(STRING).description("이름"),
+          fieldWithPath("data[].user.course").type(STRING).description("코스"),
+          fieldWithPath("data[].user.generation").type(NUMBER).description("기수"),
+          fieldWithPath("data[].user.role").type(STRING).description("역할"),
+          fieldWithPath("data[].user.createdAt").type(STRING).description("가입일자"),
+          fieldWithPath("data[].introduction").type(OBJECT).description("자기소개 정보"),
+          fieldWithPath("data[].introduction.introductionId").type(NUMBER).description("자기소개 ID"),
+          fieldWithPath("data[].introduction.profileImgUrl").type(STRING).description("프로필 이미지 URL"),
+          fieldWithPath("data[].introduction.mbti").type(STRING).description("mbti"),
+          fieldWithPath("data[].introduction.blogUrl").type(STRING).description("블로그 URL"),
+          fieldWithPath("data[].introduction.githubUrl").type(STRING).description("깃허브 URL"),
+          fieldWithPath("data[].introduction.summary").type(STRING).description("한 줄 소개"),
+          fieldWithPath("data[].introduction.latitude").type(NUMBER).description("경도"),
+          fieldWithPath("data[].introduction.longitude").type(NUMBER).description("위도"),
+          fieldWithPath("data[].introduction.createdAt").type(STRING).description("생성 일자"),
+          fieldWithPath("data[].introduction.updatedAt").type(STRING).description("수정 일자"),
+          fieldWithPath("serverDatetime").type(STRING).description("서버 시간")
+        )));
+
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/introduction/respository/IntroductionRepositoryTest.java
@@ -12,12 +12,15 @@ import com.devnity.devnity.domain.user.entity.UserRole;
 import com.devnity.devnity.domain.user.repository.CourseRepository;
 import com.devnity.devnity.domain.user.repository.GenerationRepository;
 import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.test.config.TestConfig;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+@Import(TestConfig.class)
 @DataJpaTest
 class IntroductionRepositoryTest {
 
@@ -36,7 +39,6 @@ class IntroductionRepositoryTest {
     User user = User.builder()
         .course(course)
         .generation(generation)
-        .authority(Authority.USER)
         .name("seunghun")
         .password("password")
         .role(UserRole.STUDENT)

--- a/src/test/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceTest.java
+++ b/src/test/java/com/devnity/devnity/domain/introduction/service/IntroductionServiceTest.java
@@ -1,8 +1,16 @@
 package com.devnity.devnity.domain.introduction.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.devnity.devnity.domain.introduction.dto.response.SuggestResponse;
 import com.devnity.devnity.domain.introduction.entity.Introduction;
 import com.devnity.devnity.domain.introduction.respository.IntroductionRepository;
 import com.devnity.devnity.domain.user.dto.request.SaveIntroductionRequest;
@@ -12,6 +20,10 @@ import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.Mbti;
 import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.domain.user.repository.UserRepository;
+import com.devnity.devnity.domain.user.service.UserServiceUtils;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +38,8 @@ class IntroductionServiceTest {
   @InjectMocks private IntroductionService introductionService;
 
   @Mock private IntroductionRepository introductionRepository;
+
+  @Mock private UserRepository userRepository;
 
   @DisplayName("자기소개가 저장된다")
   @Test
@@ -47,7 +61,6 @@ class IntroductionServiceTest {
         .role(UserRole.STUDENT)
         .password("password")
         .name("seunghun")
-        .authority(Authority.USER)
         .generation(new Generation(1))
         .course(new Course("FE"))
         .build();
@@ -67,6 +80,52 @@ class IntroductionServiceTest {
     assertThat(introduction.getMbti()).isEqualTo(request.getMbti());
     assertThat(introduction.getSummary()).isEqualTo(request.getSummary());
     assertThat(introduction.getProfileImgUrl()).isEqualTo(request.getProfileImgUrl());
+  }
+  
+  @DisplayName("자기소개 추천: 사용자와 기수, 코스가 동일하다")
+  @Test 
+  public void testSuggest() throws Exception {
+    // given
+
+    List<User> users = new ArrayList<>();
+    int size = 5;
+
+    for (int i = 0; i < size; i++) {
+      User user = User.builder()
+        .course(new Course("FE"))
+        .generation(new Generation(1))
+        .password("Password")
+        .role(UserRole.STUDENT)
+        .name("name" + i)
+        .email(i + "email@naver.com")
+        .build();
+
+      Introduction introduction = user.getIntroduction();
+      introduction.update(Introduction.builder()
+        .content("content" + i)
+        .summary("summary")
+        .mbti(Mbti.ENFA)
+        .profileImgUrl("profile" + i)
+        .longitude(123.123)
+        .latitude(123.123)
+        .blogUrl("blog")
+        .githubUrl("github")
+        .build());
+
+      users.add(user);
+    }
+
+    User user = users.remove(0);
+    given(userRepository.findById(any())).willReturn(Optional.of(user));
+    given(userRepository.findAllByCourseAndGenerationLimit(any(), anyInt())).willReturn(users);
+
+    // when
+    List<SuggestResponse> suggest = introductionService.suggest(user.getId());
+
+    // then
+    assertThat(suggest).hasSize(size - 1);
+    assertThat(suggest.get(0).getUser().getGeneration()).isEqualTo(user.getGenerationSequence());
+    assertThat(suggest.get(0).getUser().getCourse()).isEqualTo(user.getCourseName());
   }
   
   

--- a/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/controller/UserControllerTest.java
@@ -34,10 +34,8 @@ import com.devnity.devnity.domain.user.repository.GenerationRepository;
 import com.devnity.devnity.domain.user.repository.UserRepository;
 import com.devnity.devnity.test.annotation.WithJwtAuthUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.Collections;
 import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,9 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -255,6 +251,7 @@ class UserControllerTest {
                     fieldWithPath("data.introduction.blogUrl").type(STRING).description("블로그"),
                     fieldWithPath("data.introduction.githubUrl").type(STRING).description("깃허브"),
                     fieldWithPath("data.introduction.summary").type(STRING).description("한 줄 소개"),
+                    fieldWithPath("data.introduction.description").type(STRING).description("상세 소개"),
                     fieldWithPath("data.introduction.latitude").type(NUMBER).description("위도"),
                     fieldWithPath("data.introduction.longitude").type(NUMBER).description("경도"),
                     fieldWithPath("data.introduction.createdAt").type(STRING).description("생성일"),

--- a/src/test/java/com/devnity/devnity/domain/user/entity/UserTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/entity/UserTest.java
@@ -22,13 +22,14 @@ class UserTest {
     //given
     String password = "password123";
 
-    User user = User.builder()
-        .course(new Course("백엔드"))
-        .email("admin@naver.com")
-        .generation(new Generation(1))
-        .authority(Authority.USER)
-        .password(passwordEncoder.encode(password))
-        .build();
+    User user =
+        User.builder()
+            .course(new Course("백엔드"))
+            .email("admin@naver.com")
+            .generation(new Generation(1))
+            .password(passwordEncoder.encode(password))
+            .role(UserRole.STUDENT)
+            .build();
     // when
 
     // then

--- a/src/test/java/com/devnity/devnity/domain/user/repository/CourseRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/repository/CourseRepositoryTest.java
@@ -4,12 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.test.config.TestConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+@Import(TestConfig.class)
 @DataJpaTest
 class CourseRepositoryTest {
 

--- a/src/test/java/com/devnity/devnity/domain/user/repository/GenerationRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/repository/GenerationRepositoryTest.java
@@ -4,12 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.devnity.devnity.domain.user.entity.Generation;
+import com.devnity.devnity.test.config.TestConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+@Import(TestConfig.class)
 @DataJpaTest
 class GenerationRepositoryTest {
 

--- a/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
@@ -48,7 +48,6 @@ class UserRepositoryTest {
             .generation(generation)
             .role(UserRole.STUDENT)
             .email("user@gmail.com")
-            .authority(Authority.USER)
             .build();
   }
 
@@ -102,20 +101,17 @@ class UserRepositoryTest {
               .generation(generations.get(i % 2))
               .role(UserRole.STUDENT)
               .email(i + "user@gmail.com")
-              .authority(Authority.USER)
               .build());
     }
 
     userRepository.saveAll(users);
 
     // when
-    List<User> results = userRepository.findAllByCourseAndGenerationLimit(
-      course, generation, 10);
+    List<User> results = userRepository.findAllByCourseAndGenerationLimit(users.get(0), 10);
     // then
     assertThat(results).hasSize(10);
     assertThat(results.get(0).getCourse()).isEqualTo(courses.get(0));
     assertThat(results.get(0).getGeneration()).isEqualTo(generations.get(0));
+    assertThat(results.contains(users.get(0))).isFalse();
   }
-  
-  
 }

--- a/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
@@ -7,6 +7,7 @@ import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.test.config.TestConfig;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +15,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Import(TestConfig.class)
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
 class UserRepositoryTest {

--- a/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/repository/UserRepositoryTest.java
@@ -7,7 +7,10 @@ import com.devnity.devnity.domain.user.entity.Course;
 import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.User;
 import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.domain.user.entity.UserStatus;
 import com.devnity.devnity.test.config.TestConfig;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -81,4 +84,38 @@ class UserRepositoryTest {
     // then
     assertThat(result).isTrue();
   }
+  
+  @DisplayName("코스와 기수가 같은 사용자를 가져올 수 있다")
+  @Test 
+  public void testFindAllByCourseAndGenerationLimit() throws Exception {
+    //given
+    List<Course> courses = courseRepository.saveAll(List.of(course, new Course("BE")));
+    List<Generation> generations = generationRepository.saveAll(
+    List.of(generation, new Generation(2)));
+    List<User> users = new ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      users.add(
+          User.builder()
+              .course(courses.get(i % 2))
+              .password("password" + i)
+              .name("name" + i)
+              .generation(generations.get(i % 2))
+              .role(UserRole.STUDENT)
+              .email(i + "user@gmail.com")
+              .authority(Authority.USER)
+              .build());
+    }
+
+    userRepository.saveAll(users);
+
+    // when
+    List<User> results = userRepository.findAllByCourseAndGenerationLimit(
+      course, generation, 10);
+    // then
+    assertThat(results).hasSize(10);
+    assertThat(results.get(0).getCourse()).isEqualTo(courses.get(0));
+    assertThat(results.get(0).getGeneration()).isEqualTo(generations.get(0));
+  }
+  
+  
 }

--- a/src/test/java/com/devnity/devnity/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/devnity/devnity/domain/user/service/UserServiceTest.java
@@ -103,7 +103,6 @@ class UserServiceTest {
     User user = User.builder()
         .course(course)
         .generation(generation)
-        .authority(Authority.USER)
         .name("name")
         .password("password")
         .role(UserRole.STUDENT)

--- a/src/test/java/com/devnity/devnity/test/annotation/WithJwtAuthUser.java
+++ b/src/test/java/com/devnity/devnity/test/annotation/WithJwtAuthUser.java
@@ -1,14 +1,27 @@
 package com.devnity.devnity.test.annotation;
 
+import com.devnity.devnity.domain.user.entity.UserRole;
 import com.devnity.devnity.test.config.WithJwtAuthUserSecurityContext;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.springframework.security.test.context.support.WithSecurityContext;
 
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithJwtAuthUserSecurityContext.class)
 public @interface WithJwtAuthUser {
 
   String email();
-  String role();
+
+  UserRole role() default UserRole.STUDENT;
+
+  String password() default "password";
+
+  String name() default "name";
+
+  String course() default "FE";
+
+  int generation() default 1;
 }

--- a/src/test/java/com/devnity/devnity/test/config/TestConfig.java
+++ b/src/test/java/com/devnity/devnity/test/config/TestConfig.java
@@ -1,0 +1,18 @@
+package com.devnity.devnity.test.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+  @Autowired private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/test/java/com/devnity/devnity/test/config/WithJwtAuthUserSecurityContext.java
+++ b/src/test/java/com/devnity/devnity/test/config/WithJwtAuthUserSecurityContext.java
@@ -4,7 +4,13 @@ import com.devnity.devnity.domain.auth.jwt.Jwt;
 import com.devnity.devnity.domain.auth.jwt.Jwt.Claims;
 import com.devnity.devnity.domain.auth.jwt.JwtAuthentication;
 import com.devnity.devnity.domain.auth.jwt.JwtAuthenticationToken;
+import com.devnity.devnity.domain.user.entity.Authority;
+import com.devnity.devnity.domain.user.entity.Course;
+import com.devnity.devnity.domain.user.entity.Generation;
 import com.devnity.devnity.domain.user.entity.User;
+import com.devnity.devnity.domain.user.entity.UserRole;
+import com.devnity.devnity.domain.user.repository.CourseRepository;
+import com.devnity.devnity.domain.user.repository.GenerationRepository;
 import com.devnity.devnity.domain.user.repository.UserRepository;
 import com.devnity.devnity.test.annotation.WithJwtAuthUser;
 import java.util.Arrays;
@@ -18,31 +24,53 @@ public class WithJwtAuthUserSecurityContext implements WithSecurityContextFactor
 
   private final Jwt jwt;
   private final UserRepository userRepository;
+  private final CourseRepository courseRepository;
+  private final GenerationRepository generationRepository;
 
-  public WithJwtAuthUserSecurityContext(Jwt jwt, UserRepository userRepository) {
+  public WithJwtAuthUserSecurityContext(
+      Jwt jwt,
+      UserRepository userRepository,
+      CourseRepository courseRepository,
+      GenerationRepository generationRepository) {
+
     this.jwt = jwt;
     this.userRepository = userRepository;
+    this.courseRepository = courseRepository;
+    this.generationRepository = generationRepository;
   }
 
   @Override
   public SecurityContext createSecurityContext(WithJwtAuthUser withJwtAuthUser) {
     String email = withJwtAuthUser.email();
-    String role = withJwtAuthUser.role();
-    User user = userRepository
-        .findUserByEmail(email)
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    String.format("There is no user for email = %s", email)));
+    UserRole role = withJwtAuthUser.role();
+    String courseName = withJwtAuthUser.course();
+    String name = withJwtAuthUser.name();
+    int sequence = withJwtAuthUser.generation();
+    String password = withJwtAuthUser.password();
 
-    String jwtToken = jwt.sign(Claims.from(user.getId(), email, role));
+    Generation generation = generationRepository.findBySequence(withJwtAuthUser.generation())
+      .orElseGet(() -> generationRepository.save(new Generation(sequence)));
+
+    Course course = courseRepository.findByName(courseName)
+      .orElseGet(() -> courseRepository.save(new Course(courseName)));
+
+    User user = userRepository.save(User.builder()
+      .email(email)
+      .name(name)
+      .role(role)
+      .password(password)
+      .generation(generation)
+      .course(course)
+      .build());
+
+    String jwtToken = jwt.sign(Claims.from(user.getId(), email, role.toString()));
 
     JwtAuthentication authentication = new JwtAuthentication(jwtToken, user.getId(), email);
     JwtAuthenticationToken jwtAuthenticationToken =
         new JwtAuthenticationToken(
             authentication,
             user.getPassword(),
-            new SimpleGrantedAuthority(role));
+            new SimpleGrantedAuthority(role.toString()));
 
     SecurityContextHolder.getContext().setAuthentication(jwtAuthenticationToken);
     return SecurityContextHolder.getContext();


### PR DESCRIPTION
## ❓ 관련 이슈 <!-- 해당 PR과 관련된 모든 이슈의 태그를 걸어주세요  (ex : - #이슈번호) -->

- #69 

<br>

## 💨 한줄 요약 <!-- 해당 PR에 한줄로 요약해주세요 -->

메인페이지에서 로그인한 사용자와 동일한 기수, 코스를 가진 다른 사람의 자기소개를 추천해주는 기능을 구현하였습니다.

<br>


## ✔ 변경사항 <!-- 변경된 사항에 대해 설명해주세요 -->

- @WithJwtAuthUser 기능 변경
	- 기존에는 사용자를 테스트 로직에서 저장하고 불러왔습니다.
	- 그런데 이와 같은 동작 방식이 @BeforeEach 어노테이션과 함께 사용할 때 한계가 있어 코드를 수정하였습니다
	- 사용자에게 필요한 값들을 입력 받고 Repository를 통해 어노테이션 로직에서 사용자를 생성하고 저장하는 것으로 변경되었습니다. 

<br>

## ⚠ 특이사항 <!-- 특이사항(다른 사람의 패키지를 변경)이 있다면 해당 인원을 태그하고 설명해주세요. (ex : @깃허브ID)  -->



<br>

## ⏰ 소요시간 <!-- 해당 작업이 걸린 시간을 대략적으로 써주세요 (ex : 3h) -->

4H

<br>


