### PR TITLE
[Auth] Invitation 엔티티 수정

### DIFF
--- a/src/main/java/com/devnity/devnity/domain/admin/controller/AdminInvitationController.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/controller/AdminInvitationController.java
@@ -20,13 +20,13 @@ public class AdminInvitationController {
   private final AdminInvitationService service;
 
   @PostMapping
-  public ApiResponse<Map<String, UUID>> create(@RequestBody InvitationRequest req) {
+  public ApiResponse<Map<String, String>> create(@RequestBody InvitationRequest req) {
     var uuid = service.create(req);
     return ApiResponse.ok(Collections.singletonMap("uuid", uuid));
   }
 
   @DeleteMapping("/{uuid}")
-  public ApiResponse<String> delete(@PathVariable("uuid") UUID uuid){
+  public ApiResponse<String> delete(@PathVariable("uuid") String uuid){
     String response = service.delete(uuid);
     return ApiResponse.ok(response);
   }

--- a/src/main/java/com/devnity/devnity/domain/admin/dto/InvitationDto.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/dto/InvitationDto.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Builder
 public class InvitationDto {
 
-  UUID uuid;
+  String uuid;
   String course;
   Integer generation;
   UserRole role;

--- a/src/main/java/com/devnity/devnity/domain/admin/entity/Invitation.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/entity/Invitation.java
@@ -23,8 +23,8 @@ import java.util.UUID;
 public class Invitation extends BaseEntity {
 
   @Id
-  @Column(name = "uuid", nullable = false, length = 30)
-  private UUID uuid;
+  @Column(name = "uuid", nullable = false, length = 60)
+  private String uuid;
 
   @Column(name = "course", nullable = false, length = 20)
   private String course;
@@ -41,7 +41,7 @@ public class Invitation extends BaseEntity {
 
   @Builder
   public Invitation(String course, Integer generation, UserRole role, LocalDate deadline) {
-    this.uuid = UUID.randomUUID();
+    this.uuid = UUID.randomUUID().toString();
     this.course = course;
     this.generation = generation;
     this.role = role;

--- a/src/main/java/com/devnity/devnity/domain/admin/repository/InvitationRepository.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/repository/InvitationRepository.java
@@ -12,11 +12,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
-  Optional<Invitation> findByUuid(UUID uuid);
+  Optional<Invitation> findByUuid(String uuid);
 
   boolean existsByCourseAndGenerationAndRole(String course, Integer generation, UserRole role);
 
-  void deleteByUuid(UUID uuid);
+  void deleteByUuid(String uuid);
 
   @Query("SELECT i FROM Invitation AS i WHERE CURRENT_TIMESTAMP > i.deadline.deadline")
   List<Invitation> findExpiredInvitation();

--- a/src/main/java/com/devnity/devnity/domain/admin/service/AdminInvitationService.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/service/AdminInvitationService.java
@@ -26,7 +26,7 @@ public class AdminInvitationService {
   private final InvitationRepository repository;
 
   @Transactional
-  public UUID create(InvitationRequest req) {
+  public String create(InvitationRequest req) {
     String course = req.getCourse();
     Integer generation = req.getGeneration();
     UserRole role = req.getRole();
@@ -41,7 +41,7 @@ public class AdminInvitationService {
   }
 
   @Transactional
-  public String delete(UUID uuid){
+  public String delete(String uuid){
     repository.deleteByUuid(uuid);
     return "delete success";
   }

--- a/src/main/java/com/devnity/devnity/domain/admin/service/AdminRetrieveService.java
+++ b/src/main/java/com/devnity/devnity/domain/admin/service/AdminRetrieveService.java
@@ -16,7 +16,7 @@ public class AdminRetrieveService {
 
   private final InvitationRepository repository;
 
-  public Invitation getInvitation(UUID uuid) {
+  public Invitation getInvitation(String uuid) {
     return repository.findByUuid(uuid)
       .orElseThrow(() -> new EntityNotFoundException(
         String.format("초대링크를 찾을 수 없습니다. (uuid : %s)", uuid),

--- a/src/main/java/com/devnity/devnity/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/devnity/devnity/domain/auth/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
   }
 
   @GetMapping("/links/{uuid}")
-  public ApiResponse<SignUpInfoResponse> getSignUpInfo(@PathVariable UUID uuid) {
+  public ApiResponse<SignUpInfoResponse> getSignUpInfo(@PathVariable String uuid) {
     SignUpInfoResponse response = authService.getSignUpInfo(uuid);
     return ApiResponse.ok(response);
   }

--- a/src/main/java/com/devnity/devnity/domain/auth/service/AuthService.java
+++ b/src/main/java/com/devnity/devnity/domain/auth/service/AuthService.java
@@ -56,7 +56,9 @@ public class AuthService {
     return user;
   }
 
-  public SignUpInfoResponse getSignUpInfo(UUID uuid){
+  public SignUpInfoResponse getSignUpInfo(String uuid){
+    System.out.println(uuid);
+
     return SignUpInfoResponse.of(adminRetrieveService.getInvitation(uuid));
   }
 }

--- a/src/test/java/com/devnity/devnity/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/devnity/devnity/domain/auth/controller/AuthControllerTest.java
@@ -153,7 +153,6 @@ class AuthControllerTest {
     // When + Then
     mockMvc.perform(
         get("/api/v1/auth/links/{uuid}", invitation.getUuid())
-          .header("Authorization", "JSON WEB TOKEN")
           .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isOk())


### PR DESCRIPTION
## ❓ 관련 이슈 <!-- 해당 PR과 관련된 모든 이슈의 태그를 걸어주세요  (ex : - #이슈번호) -->

- 핫픽스입니다

<br>

## 💨 한줄 요약 <!-- 해당 PR에 한줄로 요약해주세요 -->

제목이 곧 요약!!!

<br>


## ✔ 변경사항 <!-- 변경된 사항에 대해 설명해주세요 -->

- Invitation 엔티티는 uuid를 PK로 가지는데, 이를 `UUID uuid` 형태로 선언하게 되면 uuid 컬럼이 테이블에 binary로 저장되게됨.
- 현재와 같은 타입을 유지하려면 DB에서 조회시마다 uuid를 파싱해줘야 하는 사태가 발생
- 따라서 최초 저장시에 UUID를 생성 후 저장시엔 String으로 변환하여 저장하게 함


<br>

## ⚠ 특이사항 <!-- 특이사항(다른 사람의 패키지를 변경)이 있다면 해당 인원을 태그하고 설명해주세요. (ex : @깃허브ID)  -->



<br>

## ⏰ 소요시간 <!-- 해당 작업이 걸린 시간을 대략적으로 써주세요 (ex : 3h) -->

- 20m


<br>


